### PR TITLE
Parsing improvements for strings and dates

### DIFF
--- a/lib/osa-parser.js
+++ b/lib/osa-parser.js
@@ -131,7 +131,11 @@ module.exports = (function() {
         peg$c82 = { type: "other", description: "date" },
         peg$c83 = "date",
         peg$c84 = { type: "literal", value: "date", description: "\"date\"" },
-        peg$c85 = function(date) { return new Date(date); },
+        peg$c85 = function(date) { dateObject = new Date(date);
+                                   if (!isNaN(dateObject.getTime()))
+                                     return dateObject;
+                                   else
+                                     return date; },
         peg$c86 = /^[0-9]/,
         peg$c87 = { type: "class", value: "[0-9]", description: "[0-9]" },
         peg$c88 = /^[0-9a-f]/i,

--- a/lib/osa-parser.js
+++ b/lib/osa-parser.js
@@ -120,16 +120,22 @@ module.exports = (function() {
                   return String.fromCharCode(parseInt(digits, 16));
                 },
         peg$c73 = function(sequence) { return sequence; },
-        peg$c74 = /^[ -!#-[\]-\u10FFFF]/,
-        peg$c75 = { type: "class", value: "[ -!#-[\\]-\\u10FFFF]", description: "[ -!#-[\\]-\\u10FFFF]" },
-        peg$c76 = { type: "other", description: "date" },
-        peg$c77 = "date",
-        peg$c78 = { type: "literal", value: "date", description: "\"date\"" },
-        peg$c79 = function(date) { return new Date(date); },
-        peg$c80 = /^[0-9]/,
-        peg$c81 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c82 = /^[0-9a-f]/i,
-        peg$c83 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
+        peg$c74 = /^[\n\t -!#-[\]-\u10FFFF]/,
+        peg$c75 = { type: "class", value: "[\\n\\t -!#-[\\]-\\u10FFFF]", description: "[\\n\\t -!#-[\\]-\\u10FFFF]" },
+        peg$c76 = { type: "other", description: "unquoted string" },
+        peg$c77 = function(first_char, chars) { return first_char+chars.join(""); },
+        peg$c78 = /^[a-z ]/,
+        peg$c79 = { type: "class", value: "[a-z ]", description: "[a-z ]" },
+        peg$c80 = /^[^,}]/,
+        peg$c81 = { type: "class", value: "[^,}]", description: "[^,}]" },
+        peg$c82 = { type: "other", description: "date" },
+        peg$c83 = "date",
+        peg$c84 = { type: "literal", value: "date", description: "\"date\"" },
+        peg$c85 = function(date) { return new Date(date); },
+        peg$c86 = /^[0-9]/,
+        peg$c87 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c88 = /^[0-9a-f]/i,
+        peg$c89 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -510,7 +516,10 @@ module.exports = (function() {
                 if (s0 === peg$FAILED) {
                   s0 = peg$parsedate();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseraw();
+                    s0 = peg$parseunquoted_string();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseraw();
+                    }
                   }
                 }
               }
@@ -1336,30 +1345,23 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parsedate() {
+    function peg$parseunquoted_string() {
       var s0, s1, s2, s3;
 
       peg$silentFails++;
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c77) {
-        s1 = peg$c77;
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
-      }
+      s1 = peg$parsefirst_unquoted_char();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsews();
+        s2 = [];
+        s3 = peg$parseunquoted_char();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseunquoted_char();
+        }
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsestring();
-          if (s3 !== peg$FAILED) {
-            peg$reportedPos = s0;
-            s1 = peg$c79(s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$c0;
-          }
+          peg$reportedPos = s0;
+          s1 = peg$c77(s1, s2);
+          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$c0;
@@ -1377,7 +1379,21 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parseDIGIT() {
+    function peg$parsefirst_unquoted_char() {
+      var s0;
+
+      if (peg$c78.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseunquoted_char() {
       var s0;
 
       if (peg$c80.test(input.charAt(peg$currPos))) {
@@ -1391,15 +1407,70 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parseHEXDIG() {
+    function peg$parsedate() {
+      var s0, s1, s2, s3;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4) === peg$c83) {
+        s1 = peg$c83;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsews();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsestring();
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c85(s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c0;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c0;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseDIGIT() {
       var s0;
 
-      if (peg$c82.test(input.charAt(peg$currPos))) {
+      if (peg$c86.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c83); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseHEXDIG() {
+      var s0;
+
+      if (peg$c88.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
 
       return s0;

--- a/lib/osa-parser.peg
+++ b/lib/osa-parser.peg
@@ -127,7 +127,11 @@ unquoted_char = [^,}]
 /* ----- 8. Date ----- */
 
 date "date"
- = "date" ws date:string { return new Date(date); }
+ = "date" ws date:string { dateObject = new Date(date);
+                           if (!isNaN(dateObject.getTime()))
+                             return dateObject;
+                           else
+                             return date; }
 
 
 /* ----- Core ABNF Rules ----- */

--- a/lib/osa-parser.peg
+++ b/lib/osa-parser.peg
@@ -22,6 +22,7 @@ value
   / number
   / string
   / date
+  / unquoted_string
   / raw
 
 false = "false" { return false; }
@@ -114,7 +115,13 @@ char
 
 escape         = "\\"
 quotation_mark = '"'
-unescaped      = [\x20-\x21\x23-\x5B\x5D-\u10FFFF]
+unescaped      = [\n\t\x20-\x21\x23-\x5B\x5D-\u10FFFF]
+
+unquoted_string "unquoted string"
+  = first_char:first_unquoted_char chars:unquoted_char* { return first_char+chars.join(""); }
+
+first_unquoted_char = [a-z ] /* [^,}"] */
+unquoted_char = [^,}]
 
 
 /* ----- 8. Date ----- */

--- a/tests/independent/osaparser_test.js
+++ b/tests/independent/osaparser_test.js
@@ -49,6 +49,12 @@ module.exports = {
     test.done();
   },
 
+  preserveOriginalStringInDate: function(test) {
+    test.expect(1);
+    test.equal(parse('date "Date in format unrecognized by Javascript"'), 'Date in format unrecognized by Javascript', "Preserve original date string when Javascript cannot parse it");
+    test.done();
+  },
+
   parseEmpty : function(test){
     test.expect(1);
     test.equal(parse(''), null, "Should be emtpy");
@@ -56,15 +62,15 @@ module.exports = {
   },
 
   parseMultilineString: function(test) {
-    test.expect(1)
-    test.deepEqual(parse('{foo:"bar\n\tbaz"}'), {"foo": "bar\n\tbaz"}, "String with line-breaks and tab characters")
-    test.done()
+    test.expect(1);
+    test.deepEqual(parse('{foo:"bar\n\tbaz"}'), {"foo": "bar\n\tbaz"}, "String with line-breaks and tab characters");
+    test.done();
   },
 
   parseUnquotedString: function(test) {
-    test.expect(2)
-    test.deepEqual(parse('{foo:simple string value without quotes}'), {"foo": "simple string value without quotes"}, "Simple string value without quotes")
-    test.deepEqual(parse('{foo: project id "111-222-333" of application "Things"}'), {"foo": "project id \"111-222-333\" of application \"Things\""}, "Unquoted string value with quotes inside")
-    test.done()
+    test.expect(2);
+    test.deepEqual(parse('{foo:simple string value without quotes}'), {"foo": "simple string value without quotes"}, "Simple string value without quotes");
+    test.deepEqual(parse('{foo: project id "111-222-333" of application "Things"}'), {"foo": "project id \"111-222-333\" of application \"Things\""}, "Unquoted string value with quotes inside");
+    test.done();
   }
 };

--- a/tests/independent/osaparser_test.js
+++ b/tests/independent/osaparser_test.js
@@ -53,6 +53,18 @@ module.exports = {
     test.expect(1);
     test.equal(parse(''), null, "Should be emtpy");
     test.done();
-  }
+  },
 
+  parseMultilineString: function(test) {
+    test.expect(1)
+    test.deepEqual(parse('{foo:"bar\n\tbaz"}'), {"foo": "bar\n\tbaz"}, "String with line-breaks and tab characters")
+    test.done()
+  },
+
+  parseUnquotedString: function(test) {
+    test.expect(2)
+    test.deepEqual(parse('{foo:simple string value without quotes}'), {"foo": "simple string value without quotes"}, "Simple string value without quotes")
+    test.deepEqual(parse('{foo: project id "111-222-333" of application "Things"}'), {"foo": "project id \"111-222-333\" of application \"Things\""}, "Unquoted string value with quotes inside")
+    test.done()
+  }
 };


### PR DESCRIPTION
I'm using your library to extract data from the [Things app](http://culturedcode.com/things/), so I encountered some issues with the output parser:

* The strings returned from `osascript` may contain literal newlines and tab characters. Maybe some other whitespace characters, too.
* In some cases simple string values are returned without quotes; sometimes there's a string value that has quotes in it, but it's still not quoted (see the tests for an example).
* The date format returned from `osascript` isn't guaranteed to be parseable by Javascript, so you're left with an `Invalid date` and nothing to work off; I added a fallback that returns the original unparsed string in such cases.

Fixes and tests are below.

Thanks for making the parser!