### PR TITLE
Fix for Node 6.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,13 @@ var bufferStream = function(stream){
 
 var execute = function ( path, script, vars, cb ) {
   if ( cb === undefined ) cb = vars;
+  if ( typeof path !== 'undefined') {
+    opts = { cwd: dirname(path) }
+  } else {
+    opts = {}
+  }
 
-  var cp = spawn("osascript", ["-ss", "-"], { cwd: dirname(path) });
+  var cp = spawn("osascript", ["-ss", "-"], opts);
 
   var outBuffer = bufferStream(cp.stdout);
   var errBuffer = bufferStream(cp.stderr);


### PR DESCRIPTION
This PR fixes an error that appears on Node 6.0.

The [latest release of Node](https://nodejs.org/en/blog/release/v6.0.0/) made a [breaking change](https://github.com/nodejs/node/pull/5348) to the `path` module, which now throws an error if it's passed `undefined` instead of a string. To fix the exception, this PR adds a type-check to ensure we only ever pass a string to `path`.